### PR TITLE
feat: Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,21 @@ electron-comrade --electron path/to/electron --app path/to/app
 Running an installed app with a different version of Electron:
 
 Windows:
+
 ```powershell
 electron-comrade --electron 3.0.9 --app ~\AppData\Local\slack\app-3.3.4\
 ```
 
-macOS
+macOS:
+
 ```sh
 electron-comrade --electron 3.0.9 --app /Applications/Slack.app
+```
+
+Linux:
+
+```sh
+electron-comrade --electron 3.0.9 --app /usr/lib/slack
 ```
 
 Running an installed app with a local build of Electron:

--- a/package.json
+++ b/package.json
@@ -26,10 +26,6 @@
   "bugs": {
     "url": "https://github.com/felixrieseberg/electron-comrade/issues"
   },
-  "os": [
-    "win32",
-    "darwin"
-  ],
   "homepage": "https://github.com/felixrieseberg/electron-comrade#readme",
   "devDependencies": {
     "@types/chalk": "^2.2.0",

--- a/src/utils/app-folder.ts
+++ b/src/utils/app-folder.ts
@@ -6,21 +6,18 @@ import { IArgs } from 'src/interfaces';
 export function getResourcesDirFromRoot(input: string) {
   if (process.platform === 'darwin') {
     return path.join(input, 'Electron.app', 'Contents', 'Resources');
-  }
-
-  if (process.platform === 'win32') {
+  } else {
     return path.join(input, 'resources');
   }
 }
 
 export async function getAppFolder(options: IArgs): Promise<string | null> {
-  if (process.platform === 'win32') {
-    return getAppFolderWin(options);
-  }
-
   if (process.platform === 'darwin') {
     return getAppFolderMac(options);
+  } else {
+    return getAppFolderNonMac(options);
   }
+
 }
 
 export async function getAppFolderMac({ app }: IArgs): Promise<string | null> {
@@ -29,7 +26,7 @@ export async function getAppFolderMac({ app }: IArgs): Promise<string | null> {
     : app;
 }
 
-export async function getAppFolderWin({ app }: IArgs): Promise<string | null> {
+export async function getAppFolderNonMac({ app }: IArgs): Promise<string | null> {
   const contents = await fs.readdir(app);
 
   return contents.indexOf('resources') > -1

--- a/src/utils/electron-bin.ts
+++ b/src/utils/electron-bin.ts
@@ -1,9 +1,7 @@
 export function getElectronBin() {
-  if (process.platform === 'win32') {
-    return 'electron.exe';
-  }
-
-  if (process.platform === 'darwin') {
-    return `Electron.app/Contents/MacOS/Electron`;
+  switch (process.platform) {
+    case 'win32': return 'electron.exe';
+    case 'darwin': return `Electron.app/Contents/MacOS/Electron`;
+    default: return 'electron';
   }
 }


### PR DESCRIPTION
There was a person on the atomio Slack #electron channel who wanted to use Slack with a different Electron on Linux due to having a too-new glibc (I assume https://github.com/electron/electron/issues/13972), so I pointed them at this repo. Little did I know that there was no Linux support, so I decided to add it. 

The hilarious thing (to me) is that this PR is net negative LoC :laughing: 